### PR TITLE
Update Link.php

### DIFF
--- a/cleanurls/override/classes/Link.php
+++ b/cleanurls/override/classes/Link.php
@@ -29,8 +29,22 @@ class Link extends LinkCore
 		$params = array();
 		$params['id'] = $category->id;
 		$params['rewrite'] = (!$alias) ? $category->link_rewrite : $alias;
-		$params['meta_keywords'] =	Tools::str2url($category->meta_keywords);
-		$params['meta_title'] = Tools::str2url($category->meta_title);
+		
+		/* 
+		/* keywords and metatitle can be supplied by PS as an array, if so make
+		/* sure we implode to a single string for further processing by str2url
+		*/
+		$tmpKwds = $category->meta_keywords;
+		if(is_array($tmpKwds))	{
+			$tmpKwds = implode(" ", $category->meta_keywords);
+		}
+		$params['meta_keywords'] = Tools::str2url($tmpKwds);
+		
+		$tmpTitle = $category->meta_title;
+		if(is_array($tmpTitle)) {
+			$tmpTitle = implode(" ", $category->meta_title);
+		}
+		$params['meta_title'] = Tools::str2url($tmpTitle);
 
 		// Selected filters is used by the module blocklayered
 		$selected_filters = is_null($selected_filters) ? '' : $selected_filters;


### PR DESCRIPTION
Meta keywords and title can be passed to the function as an array or string.
This update ensures that the array is flatened to a single string prior to asking Tools:str2url to work with it.

If Tools::str2url recieves an array it throws our lots of 'Warning' messages when PHP debugging is enabled in PS.
