### PR TITLE
301 redirects and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [ABOUT]
 ===============================================================
 Adaptation of CleanURLs module originally created by Ha99y and modified by Lebioda and Lapy90
+
 https://github.com/Ha99y/PrestaShop-modules-CleanURLs
+
 http://lebioda.github.io/PrestaShop-modules-CleanURLs/
 
 CHANGES

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-[ABOUT](http://lebioda.github.io/PrestaShop-modules-CleanURLs/)
+[ABOUT]
 ===============================================================
+Adaptation of CleanURLs module originally created by Ha99y and modified by Lebioda and Lapy90
+https://github.com/Ha99y/PrestaShop-modules-CleanURLs
+http://lebioda.github.io/PrestaShop-modules-CleanURLs/
+
+CHANGES
+--------
+Fixed an issue that was being experienced with .html on product pages
+
+INSTALLATION
+--------
+
+Install the module from the Backoffice (administration panel)
+
+In the modules tab, click on add a new module. Click on Browse to open the dialogue box letting you search your computer, select the file then validate the dialogue box. Finally click on Upload this module.
+
+
+UNINSTALLATION
+--------
+
+Go to modules -> Find and uninstall "CleanURL".
+
+Open folder /override/classes/
+-> Remove "Link.php"
+-> Remove "Dispatcher.php"
+
+Open folder /override/controllers/front/
+-> Remove "CategoryController.php"
+-> Remove "CmsController.php"
+-> Remove "ManufacturerController.php"
+-> Remove "ProductController.php"
+-> Remove "SupplierController.php"
+
+Open folder /cache/
+-> Remove "class_index.php"
+
+Go to back office -> Preferences -> SEO and URLs -> Set userfriendly URL off -> Save
+Go to back office -> Preferences -> SEO and URLs -> Set userfriendly URL on -> Save
+
+If you got any other override modules, you should now go to you back office, uninstall them, and reinstall them again to work correctly.
+

--- a/cleanurls/cleanurls.php
+++ b/cleanurls/cleanurls.php
@@ -12,6 +12,7 @@
 * This code is provided as is without any warranty.
 * No promise of being safe or secure
 *
+*  @adapted by  mnwalker / AWcode
 *  @author      Ha!*!*y <ha99ys@gmail.com>
 *  @copyright   2012-2013 Ha!*!*y
 *  @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
@@ -24,9 +25,9 @@ class cleanurls extends Module
 	{
 		$this->name = 'cleanurls';
 		$this->tab = 'seo';
-		$this->version = '0.42.1';
+		$this->version = '0.6.0';
 		$this->need_instance = 0;
-		$this->author = 'ha!*!*y';
+		$this->author = 'AWcode';
 
 		parent::__construct();
 
@@ -45,21 +46,21 @@ class cleanurls extends Module
 				Go to back office -> Preferences -> SEO and URLs -> Set userfriendly URL on -> Save<br />
 			</div><br />';
 
-		$sql = 'SELECT * FROM `'._DB_PREFIX_.'product_lang`
+		$sql = 'SELECT id_lang, name, id_product, link_rewrite FROM `'._DB_PREFIX_.'product_lang`
 				WHERE `link_rewrite`
 					IN (SELECT `link_rewrite` FROM `'._DB_PREFIX_.'product_lang`
 					GROUP BY `link_rewrite`, `id_lang`
-					HAVING count(`link_rewrite`) > 1)';
+					HAVING count(`link_rewrite`) > 1) LIMIT 20';
 
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{
 			$sql .= ' AND `id_shop` = '.(int)Shop::getContextShopID();
 		}
-
-		if ($results = (int)Db::getInstance()->ExecuteS($sql))
+		$results = Db::getInstance()->ExecuteS($sql);
+		if (count($results))
 		{
 			$output .= 'You need to fix duplicate URL entries<br/>';
-			foreach ($results AS $row)
+			foreach ($results as $row)
 			{
 				$language_info = $this->context->language->getLanguage($row['id_lang']);
 				$output .= $row['name'].' ('.$row['id_product'] .') - '. $row['link_rewrite'].'<br/>';

--- a/cleanurls/config.xml
+++ b/cleanurls/config.xml
@@ -2,9 +2,9 @@
         <module>
             <name>cleanurls</name>
             <displayName><![CDATA[Very Clean URLs]]></displayName>
-            <version><![CDATA[0.5]]></version>
-            <description><![CDATA[This override allows you to remove URL ID&#039;s. + FIX BY LAPY90 + FIX by Lebioda: It allows to use templates to achieve links like domain.com/link]]></description>
-            <author><![CDATA[ha!*!*y + Lapy90 + Lebioda]]></author>
+            <version><![CDATA[0.6]]></version>
+            <description><![CDATA[This override allows you to remove URL ID&#039;s. + FIX BY AWcode + FIX BY LAPY90 + FIX by Lebioda: It allows to use templates to achieve links like domain.com/link]]></description>
+            <author><![CDATA[AWcode + ha!*!*y + Lapy90 + Lebioda]]></author>
             <tab><![CDATA[seo]]></tab>
             <is_configurable>1</is_configurable>
             <need_instance>0</need_instance>

--- a/cleanurls/override/classes/Dispatcher.php
+++ b/cleanurls/override/classes/Dispatcher.php
@@ -231,7 +231,7 @@ class Dispatcher extends DispatcherCore
 	public static function isManufacturerLink($short_link)
 	{
 		// check if any keyword
-		$explode_manufacturer_link = explode("/", $short_link, 2);
+		$explode_manufacturer_link = explode("/", $short_link);
 
 		$count = count($explode_manufacturer_link);
 		if($explode_manufacturer_link[$count-1] == ""){

--- a/cleanurls/override/classes/Dispatcher.php
+++ b/cleanurls/override/classes/Dispatcher.php
@@ -113,7 +113,7 @@ class Dispatcher extends DispatcherCore
 		
 		$sql = 'SELECT `id_product`
 			FROM `'._DB_PREFIX_.'product_lang`
-			WHERE `link_rewrite` = \''.$explode_product_link[$count-1].'\' AND `id_lang` = '. Context::getContext()->language->id;
+			WHERE (`link_rewrite` = \''.$explode_product_link[$count-1].'\' OR `link_rewrite` = \''.str_replace(".html", "",$explode_product_link[$count-1]).'\') AND `id_lang` = '. Context::getContext()->language->id;
 
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{

--- a/cleanurls/override/classes/Dispatcher.php
+++ b/cleanurls/override/classes/Dispatcher.php
@@ -117,11 +117,26 @@ class Dispatcher extends DispatcherCore
 
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{
-			$sql .= ' AND `id_shop` = '.(int)Shop::getContextShopID();
+			$sql2 = ' AND `id_shop` = '.(int)Shop::getContextShopID();
 		}
 
-		$id_product = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
-			
+		$id_product = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+		
+		if(!$id_product){
+			$split = explode("-", $explode_product_link[$count-1], 2);
+			if(count($split) == 2 && is_numeric($split[0])){
+				$sql = 'SELECT `id_product`
+					FROM `'._DB_PREFIX_.'product_lang`
+					WHERE (`link_rewrite` = \''.$split[1].'\' OR `link_rewrite` = \''.str_replace(".html", "",$split[1]).'\') 
+					AND `id_product` = "'.$split[0].'" AND `id_lang` = '. Context::getContext()->language->id;
+				$redirect = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+				if($redirect){
+					$url = (($_SERVER['HTTPS'])?"https://":"http://") . $_SERVER['HTTP_HOST'] . str_replace($split[0]."-".$split[1], $split[1], $_SERVER['REQUEST_URI']);
+					Tools::redirect($url);
+				}
+			}
+		}
+				
 		return ($id_product > 0) ? true : false;
 	}
 	
@@ -141,10 +156,24 @@ class Dispatcher extends DispatcherCore
 
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{
-			$sql .= ' AND `id_shop` = '.(int)Shop::getContextShopID();
+			$sql2 = ' AND `id_shop` = '.(int)Shop::getContextShopID();
 		}
 		
-		$id_category = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+		$id_category = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+		
+		if(!$id_category){
+			$split = explode("-", $categories[0], 2);
+			if(count($split) == 2 && is_numeric($split[0])){
+				$sql = 'SELECT `id_category` FROM `'._DB_PREFIX_.'category_lang`
+					WHERE `link_rewrite` = \''.$split[1].'\'
+					AND `id_category` = "'.$split[0].'" AND `id_lang` = '. Context::getContext()->language->id;
+				$redirect = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+				if($redirect){
+					$url = (($_SERVER['HTTPS'])?"https://":"http://") . $_SERVER['HTTP_HOST'] . str_replace($split[0]."-".$split[1], $split[1], $_SERVER['REQUEST_URI']);
+					Tools::redirect($url);
+				}
+			}
+		}
 					
 		return ($id_category > 0) ? true : false;
 	}
@@ -168,10 +197,27 @@ class Dispatcher extends DispatcherCore
 
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{
-			$sql .= ' AND s.`id_shop` = '.(int)Shop::getContextShopID();
+			$sql2 = ' AND s.`id_shop` = '.(int)Shop::getContextShopID();
 		}
 
-		$id_cms = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+		$id_cms = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+		
+		if(!$id_cms){
+			$split = explode("-", $explode_cms_link[$count-1], 2);
+			if(count($split) == 2 && is_numeric($split[0])){
+				$sql = 'SELECT l.`id_cms`
+					FROM `'._DB_PREFIX_.'cms_lang` l
+					LEFT JOIN `'._DB_PREFIX_.'cms_shop` s ON (l.`id_cms` = s.`id_cms`)
+					WHERE l.`link_rewrite` = \''.$split[1].'\'
+					AND l.`id_cms` = "'.$split[0].'"';
+
+				$redirect = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+				if($redirect){
+					$url = (($_SERVER['HTTPS'])?"https://":"http://") . $_SERVER['HTTP_HOST'] . str_replace($split[0]."-".$split[1], $split[1], $_SERVER['REQUEST_URI']);
+					Tools::redirect($url);
+				}
+			}
+		}
 					
 		return ($id_cms > 0) ? true : false;
 	}
@@ -197,10 +243,27 @@ class Dispatcher extends DispatcherCore
 	
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{
-			$sql .= ' AND s.`id_shop` = '.(int)Shop::getContextShopID();
+			$sql2 = ' AND s.`id_shop` = '.(int)Shop::getContextShopID();
 		}
 
-		$id_manufacturer = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+		$id_manufacturer = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+		
+		if(!$id_manufacturer){
+			$split = explode("-", $name_manufacturer, 2);
+			if(count($split) == 2 && is_numeric($split[0])){
+				$sql = 'SELECT m.`id_manufacturer`
+						FROM `'._DB_PREFIX_.'manufacturer` m
+						LEFT JOIN `'._DB_PREFIX_.'manufacturer_shop` s ON (m.`id_manufacturer` = s.`id_manufacturer`)
+						WHERE m.`name` LIKE \''.$split[1].'\'
+						AND m.`id_manufacturer` = "'.$split[0].'"';
+
+				$redirect = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+				if($redirect){
+					$url = (($_SERVER['HTTPS'])?"https://":"http://") . $_SERVER['HTTP_HOST'] . str_replace($split[0]."-".$split[1], $split[1], $_SERVER['REQUEST_URI']);
+					Tools::redirect($url);
+				}
+			}
+		}
 					
 		return ($id_manufacturer > 0) ? true : false;
 	}
@@ -226,10 +289,27 @@ class Dispatcher extends DispatcherCore
 
 		if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 		{
-			$sql .= ' AND s.`id_shop` = '.(int)Shop::getContextShopID();
+			$sql2 = ' AND s.`id_shop` = '.(int)Shop::getContextShopID();
 		}
 
-		$id_supplier = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+		$id_supplier = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+		
+		if(!$id_supplier){
+			$split = explode("-", $explode_supplier_link[$count-1], 2);
+			if(count($split) == 2 && is_numeric($split[0])){
+				$sql = 'SELECT sp.`id_supplier`
+						FROM `'._DB_PREFIX_.'supplier` sp
+						LEFT JOIN `'._DB_PREFIX_.'supplier_shop` s ON (sp.`id_supplier` = s.`id_supplier`)
+						WHERE sp.`name` LIKE \''.$split[1].'\'
+						AND sp.`id_supplier` = "'.$split[0].'"';
+
+				$redirect = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql.$sql2);
+				if($redirect){
+					$url = (($_SERVER['HTTPS'])?"https://":"http://") . $_SERVER['HTTP_HOST'] . str_replace($split[0]."-".$split[1], $split[1], $_SERVER['REQUEST_URI']);
+					Tools::redirect($url);
+				}
+			}
+		}
 					
 		return ($id_supplier > 0) ? true : false;
 	}

--- a/cleanurls/override/classes/Dispatcher.php
+++ b/cleanurls/override/classes/Dispatcher.php
@@ -231,8 +231,13 @@ class Dispatcher extends DispatcherCore
 	public static function isManufacturerLink($short_link)
 	{
 		// check if any keyword
-		$explode_manufacturer_link = explode("/", $short_link);
+		$explode_manufacturer_link = explode("/", $short_link, 2);
+
 		$count = count($explode_manufacturer_link);
+		if($explode_manufacturer_link[$count-1] == ""){
+			unset($explode_manufacturer_link[$count-1]);
+			$count = count($explode_manufacturer_link);
+		}
 		
 		$name_manufacturer = str_replace('-', '%', $explode_manufacturer_link[$count-1]);
 

--- a/cleanurls/override/controllers/front/ProductController.php
+++ b/cleanurls/override/controllers/front/ProductController.php
@@ -12,7 +12,7 @@ class ProductController extends ProductControllerCore
 
 			$sql = 'SELECT `id_product`
 				FROM `'._DB_PREFIX_.'product_lang`
-				WHERE `link_rewrite` = \''.$rewrite_url.'\' AND `id_lang` = '. Context::getContext()->language->id;
+				WHERE (`link_rewrite` = \''.$rewrite_url.'\' OR `link_rewrite` = \''.str_replace(".html", "",$rewrite_url).'\') AND `id_lang` = '. Context::getContext()->language->id;
 
 			if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
 			{


### PR DESCRIPTION
Fixed a few little issues.
Config page had an array cast to int rendering a foreach useless.
Dispatcher was searching for product urls containing .html, while database had them without .html. Made it check both ways round.

And the big update, have made automatic 301 redirects for any old style links that have the id- infront of the name. This is essential for anyone using this module on an existing website otherwise all SEO benefits can be wiped out.
